### PR TITLE
Update to Font Awesome 6

### DIFF
--- a/javascripts/discourse/initializers/initialize-for-pdf-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-pdf-preview.js
@@ -16,7 +16,7 @@ export default {
         const previewModeSetting = settings.preview_mode;
         const newTabIcon = () => {
           const template = document.createElement("template");
-          template.innerHTML = iconHTML("external-link-alt", {
+          template.innerHTML = iconHTML("fa-solid fa-arrow-up-right-from-square", {
             class: "new-tab-pdf-icon",
           });
           return template.content.firstChild;


### PR DESCRIPTION
Update Font Awesome icon to version 6 in `initialize-for-pdf-preview.js`

* Replace `external-link-alt` with `fa-solid fa-arrow-up-right-from-square` in the `newTabIcon` function
